### PR TITLE
[issue-6-add-python-requires] add python_requires on setup.py file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         ("Programming Language :: Python :: " "Implementation :: CPython"),
     ],
+    python_requires='>=3.5',
     install_requires=INSTALL_REQUIRES,
     extras_require={
         "dev": ["codecov", "flake8", "pydocstyle", "pytest>=3.6", "pytest-cov", "tox"],


### PR DESCRIPTION
This PR adds `python_requires` restriction on `setup.py `file. 
This close issue #6 