### PR TITLE
fix: Change import urllib to urllib.request

### DIFF
--- a/pychubby/data.py
+++ b/pychubby/data.py
@@ -2,7 +2,7 @@
 
 import bz2
 import pathlib
-import urllib
+import urllib.request
 
 from pychubby.base import CACHE_FOLDER
 


### PR DESCRIPTION
changed pychubby/data.py

In python 3.x, there is an issue about import "urllib.request"
We have to import urllib.request explictly.

[referance:stackoverflow](https://stackoverflow.com/questions/37042152/python-3-5-1-urllib-has-no-attribute-request)